### PR TITLE
Updates to the latest version of Jira 7.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /installer \
     && chmod 777 /installer \
     && cd /installer
 
-ADD "https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.2.8-x64.bin" /installer/
+ADD "https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.8.2-x64.bin" /installer/
 
 COPY ./response.varfile /installer/
 COPY ./setenv.sh /installer/
@@ -12,7 +12,7 @@ COPY ./setenv.sh /installer/
 RUN chmod -R 777 /installer/ \
     && cd /installer \
     && ls -la \
-    && ./atlassian-jira-software-7.2.8-x64.bin -q -varfile response.varfile \
+    && ./atlassian-jira-software-7.8.2-x64.bin -q -varfile response.varfile \
     && rm -f /var/atlassian/application-data/.jira-home.lock \
     && mv -f /installer/setenv.sh /opt/atlassian/jira/bin/ \
     && rm -rf /installer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-Created by Pawel Rozek on March 29, 2018
+Created by Pawel Rozek on April 4, 2018
 
-Atlassian Jira 7.2.8
+Atlassian Jira 7.8.2
+
+Based on latest CentOS
 
 Home Directory can be mapped as  /var/atlassian/application-data/
 
@@ -9,12 +11,12 @@ Port to be exposed is 8080
 Installation directory /opt/atlassian/jira
 
 # How to install: #
-Pre-Requesits: 
-   - Docker and Docker Compose installed. 
+Pre-Requesits:
+   - Docker and Docker Compose installed.
    - 2 directories created for docker-compose.yml file to work.
       - /opt/atlassian
       - /opt/jiralogs
 1. Clone files to Directory on your local machine
-2. Build image: docker build -t "jira:7.2.8" ./
+2. Build image: docker build -t "jira:7.8.2" ./
 3. Run docker-compose up -d
 4. Go to http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 jira:
-  image: jira:7.2.8
+  image: jira:7.8.2
   container_name: jira
   restart: always
   volumes:

--- a/response.varfile
+++ b/response.varfile
@@ -1,5 +1,5 @@
-#install4j response file for JIRA Software 7.2.8
-#Thu Mar 29 13:25:50 EDT 2018
+#install4j response file for JIRA Software 7.8.2
+#Thu Apr 4 12:02:50 EDT 2018
 #Created by Pawel Rozek
 executeLauncherAction$Boolean=true
 app.install.service$Boolean=false

--- a/setenv.sh
+++ b/setenv.sh
@@ -11,8 +11,8 @@ JVM_SUPPORT_RECOMMENDED_ARGS=""
 #
 # The following 2 settings control the minimum and maximum given to the JIRA Java virtual machine.  In larger JIRA instances, the maximum amount will need to be increased.
 #
-#JVM_MINIMUM_MEMORY="1024m"
-#JVM_MAXIMUM_MEMORY="2048m"
+#JVM_MINIMUM_MEMORY="384m"
+#JVM_MAXIMUM_MEMORY="768m"
 
 #
 # The following are the required arguments for JIRA.
@@ -31,12 +31,10 @@ JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.ap
 #-----------------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------------
-# This allows us to actually debug GC related issues by correlating timestamps
-# with other parts of the application logs.  The second option prevents the JVM
-# from suppressing stack traces if a given type of exception occurs frequently,
-# which could make it harder for support to diagnose a problem.
+# Prevents the JVM from suppressing stack traces if a given type of exception
+# occurs frequently, which could make it harder for support to diagnose a problem.
 #-----------------------------------------------------------------------------------
-JVM_EXTRA_ARGS="-XX:+PrintGCDateStamps -XX:-OmitStackTraceInFastThrow"
+JVM_EXTRA_ARGS="-XX:-OmitStackTraceInFastThrow"
 
 PRGDIR=`dirname "$0"`
 cat "${PRGDIR}"/jirabanner.txt
@@ -54,7 +52,7 @@ if [ "$JIRA_HOME" != "" ]; then
     fi
 fi
 
-JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD}"
+JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD} ${START_JIRA_JAVA_OPTS}"
 
 export JAVA_OPTS
 
@@ -100,3 +98,16 @@ cd $PUSHED_DIR
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
 
+# Set the JVM arguments used to start JIRA. For a description of the options, see
+# http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
+
+#-----------------------------------------------------------------------------------
+# This allows us to actually debug GC related issues by correlating timestamps
+# with other parts of the application logs.
+#-----------------------------------------------------------------------------------
+GC_JVM_PARAMETERS=""
+GC_JVM_PARAMETERS="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintGCCause ${GC_JVM_PARAMETERS}"
+GC_JVM_PARAMETERS="-Xloggc:$LOGBASEABS/logs/atlassian-jira-gc-%t.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=20M ${GC_JVM_PARAMETERS}"
+
+CATALINA_OPTS="${GC_JVM_PARAMETERS} ${CATALINA_OPTS}"
+export CATALINA_OPTS


### PR DESCRIPTION
Updated the Dockerfile and docker-compose to run the latest version of Jira 7.8.2 that's available for download as of Aplir 4, 2018